### PR TITLE
Fix ArrayIndexOutOfBoundsException in 1.20.5+

### DIFF
--- a/Command Blocker Bukkit/pom.xml
+++ b/Command Blocker Bukkit/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>me.treyruffy.commandblocker</groupId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
         <artifactId>CommandBlocker</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>me.treyruffy.commandblocker</groupId>
             <artifactId>CommandBlockerShared</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/Command Blocker Bukkit/src/main/java/me/treyruffy/commandblocker/bukkit/BukkitMain.java
+++ b/Command Blocker Bukkit/src/main/java/me/treyruffy/commandblocker/bukkit/BukkitMain.java
@@ -92,6 +92,10 @@ public class BukkitMain extends JavaPlugin {
 	}
 
 	public static String getBukkitVersion() {
+		String packageName = Bukkit.getServer().getClass().getPackage().getName();
+		if (!packageName.contains("_R")) {
+			return "";
+		}
 		return Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 	}
 

--- a/Command Blocker Bukkit/src/main/java/me/treyruffy/commandblocker/bukkit/BukkitMain.java
+++ b/Command Blocker Bukkit/src/main/java/me/treyruffy/commandblocker/bukkit/BukkitMain.java
@@ -96,7 +96,7 @@ public class BukkitMain extends JavaPlugin {
 		if (!packageName.contains("_R")) {
 			return "";
 		}
-		return Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
+		return packageName.split("\\.")[3];
 	}
 
 	public static void fixCommands() {

--- a/Command Blocker Bungee/pom.xml
+++ b/Command Blocker Bungee/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>me.treyruffy.commandblocker</groupId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
         <artifactId>CommandBlocker</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>me.treyruffy.commandblocker</groupId>
             <artifactId>CommandBlockerShared</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/Command Blocker Full/pom.xml
+++ b/Command Blocker Full/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>CommandBlocker</artifactId>
         <groupId>me.treyruffy.commandblocker</groupId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -80,13 +80,13 @@
         <dependency>
             <groupId>me.treyruffy.commandblocker</groupId>
             <artifactId>CommandBlockerBukkit</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.treyruffy.commandblocker</groupId>
             <artifactId>CommandBlockerBungeeCord</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/Command Blocker Legacy/dependency-reduced-pom.xml
+++ b/Command Blocker Legacy/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>CommandBlocker</artifactId>
     <groupId>me.treyruffy.commandblocker</groupId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>CommandBlockerLegacy</artifactId>

--- a/Command Blocker Legacy/pom.xml
+++ b/Command Blocker Legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>CommandBlocker</artifactId>
         <groupId>me.treyruffy.commandblocker</groupId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/Command Blocker Shared/dependency-reduced-pom.xml
+++ b/Command Blocker Shared/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>CommandBlocker</artifactId>
     <groupId>me.treyruffy.commandblocker</groupId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>CommandBlockerShared</artifactId>

--- a/Command Blocker Shared/pom.xml
+++ b/Command Blocker Shared/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>me.treyruffy.commandblocker</groupId>
-        <version>2.1.2</version>
+        <version>2.1.3</version>
         <artifactId>CommandBlocker</artifactId>
         <relativePath>../pom.xml</relativePath>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		</license>
 	</licenses>
 
-    <version>2.1.2</version>
+    <version>2.1.3</version>
   
 	<issueManagement>
 		<system>GitHub</system>


### PR DESCRIPTION
This may be caused by PluginRemapper.

2.1.2
![1.png](https://s2.loli.net/2024/07/31/UsSqcCW7EHdMXKZ.png)

with this fix
![2.png](https://s2.loli.net/2024/07/31/4zp9aZXNGsdrF1h.png)

the jar
https://r2.wolfx.jp/files/CommandBlockerFull-2.1.3.jar